### PR TITLE
Remove the wait on slower running concurrent jobs - it's not required.

### DIFF
--- a/src/main/java/hudson/plugins/concordionpresenter/ConcordionPresenter.java
+++ b/src/main/java/hudson/plugins/concordionpresenter/ConcordionPresenter.java
@@ -54,7 +54,7 @@ public class ConcordionPresenter extends Recorder implements Serializable {
     }
 
     public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.BUILD;
+        return BuildStepMonitor.NONE;
     }
 
     @Override


### PR DESCRIPTION
The plugin's getRequiredMonitorService() returns BuildStepMonitor.BUILD. This causes concurrent builds (if enabled in jenkins) to wait on earlier, slower builds completing. This isn't required for this plugin - it's not like e.g. the junit plugin which needs to present +/- x new test failures vs previous job.